### PR TITLE
Fix session middleware import cycle

### DIFF
--- a/backend/internal/handler/login.go
+++ b/backend/internal/handler/login.go
@@ -1,15 +1,16 @@
 package handler
 
 import (
-	"context"
-	"errors"
+        "context"
+        "errors"
 
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
-	"golang.org/x/crypto/bcrypt"
+        "github.com/gofrs/uuid"
+        "github.com/jackc/pgx/v5"
+        "github.com/jackc/pgx/v5/pgtype"
+        "golang.org/x/crypto/bcrypt"
 
-	"github.com/shadowapi/shadowapi/backend/internal/session"
-	"github.com/shadowapi/shadowapi/backend/pkg/api"
+        "github.com/shadowapi/shadowapi/backend/internal/session"
+        "github.com/shadowapi/shadowapi/backend/pkg/api"
 )
 
 // PlainLogin verifies email/password and returns user UUID on success.
@@ -23,10 +24,10 @@ func (h *Handler) PlainLogin(ctx context.Context, email, password string) (strin
 		}
 		return "", err
 	}
-	if bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)) != nil {
-		return "", errors.New("invalid credentials")
-	}
-	return id.String(), nil
+        if bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)) != nil {
+                return "", errors.New("invalid credentials")
+        }
+        return uuid.UUID(id.Bytes).String(), nil
 }
 
 // SessionStatus implements session-status operation.

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -1,24 +1,28 @@
 package server
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"log/slog"
-	"net"
-	"net/http"
-	"strings"
+        "context"
+        "encoding/json"
+        "errors"
+        "fmt"
+        "log/slog"
+        "net"
+        "net/http"
+        "strings"
 
-	"github.com/gofrs/uuid"
+        "github.com/gofrs/uuid"
+        "github.com/jackc/pgx/v5"
+        "github.com/jackc/pgx/v5/pgtype"
 
-	"github.com/samber/do/v2"
+        "github.com/samber/do/v2"
 
-	"github.com/shadowapi/shadowapi/backend/internal/auth"
-	"github.com/shadowapi/shadowapi/backend/internal/config"
-	"github.com/shadowapi/shadowapi/backend/internal/handler"
-	"github.com/shadowapi/shadowapi/backend/internal/session"
-	"github.com/shadowapi/shadowapi/backend/internal/zitadel"
-	"github.com/shadowapi/shadowapi/backend/pkg/api"
+        "github.com/shadowapi/shadowapi/backend/internal/auth"
+        "github.com/shadowapi/shadowapi/backend/internal/config"
+        "github.com/shadowapi/shadowapi/backend/internal/handler"
+        "github.com/shadowapi/shadowapi/backend/internal/session"
+        "github.com/shadowapi/shadowapi/backend/internal/zitadel"
+        "github.com/shadowapi/shadowapi/backend/pkg/query"
+        "github.com/shadowapi/shadowapi/backend/pkg/api"
 )
 
 type Server struct {
@@ -28,8 +32,9 @@ type Server struct {
 	api          *api.Server
 	listener     net.Listener
 	specsHandler http.Handler
-	zitadel      *zitadel.Client
-	handler      *handler.Handler
+        zitadel      *zitadel.Client
+        handler      *handler.Handler
+        sessions     *session.Middleware
 }
 
 // Provide server instance for the dependency injector
@@ -62,14 +67,15 @@ func Provide(i do.Injector) (*Server, error) {
 		specsHandler = http.StripPrefix("/assets/docs/api", http.FileServer(http.Dir(cfg.API.SpecsDir)))
 	}
 
-	return &Server{
-		cfg:          cfg,
-		log:          do.MustInvoke[*slog.Logger](i),
-		api:          srv,
-		specsHandler: specsHandler,
-		zitadel:      zitadelClient,
-		handler:      handlerService,
-	}, nil
+        return &Server{
+                cfg:          cfg,
+                log:          do.MustInvoke[*slog.Logger](i),
+                api:          srv,
+                specsHandler: specsHandler,
+                zitadel:      zitadelClient,
+                handler:      handlerService,
+                sessions:     authMiddleware,
+        }, nil
 }
 
 // Run starts the server
@@ -134,20 +140,47 @@ func (s *Server) handleAuthCallback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing code", http.StatusBadRequest)
 		return
 	}
-	tok, err := s.zitadel.ExchangeCode(r.Context(), code)
-	if err != nil {
-		s.log.Error("exchange code", "error", err)
-		http.Error(w, "exchange failed", http.StatusInternalServerError)
-		return
-	}
-	http.SetCookie(w, &http.Cookie{
-		Name:     "zitadel_access_token",
-		Value:    tok.AccessToken,
-		Path:     "/",
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-	})
-	http.Redirect(w, r, "/", http.StatusFound)
+        tok, err := s.zitadel.ExchangeCode(r.Context(), code)
+        if err != nil {
+                s.log.Error("exchange code", "error", err)
+                http.Error(w, "exchange failed", http.StatusInternalServerError)
+                return
+        }
+
+        // Associate Zitadel subject with a user record
+        info, err := s.zitadel.Introspect(r.Context(), tok.AccessToken)
+        if err == nil && info.Active {
+                q := query.New(s.handler.DB())
+                _, errUser := q.GetUserByZitadelSubject(r.Context(), pgtype.Text{String: info.Subject, Valid: true})
+                if errors.Is(errUser, pgx.ErrNoRows) {
+                        uid := uuid.Must(uuid.NewV7())
+                        _, errUser = q.CreateUser(r.Context(), query.CreateUserParams{
+                                UUID:           pgtype.UUID{Bytes: uid, Valid: true},
+                                Email:          fmt.Sprintf("zitadel_%s@example.com", uid.String()),
+                                Password:       "",
+                                FirstName:      "",
+                                LastName:       "",
+                                IsEnabled:      true,
+                                IsAdmin:        false,
+                                ZitadelSubject: pgtype.Text{String: info.Subject, Valid: true},
+                                Meta:           []byte(`{}`),
+                        })
+                        if errUser != nil {
+                                s.log.Error("create user", "error", errUser)
+                        }
+                } else if errUser != nil {
+                        s.log.Error("lookup user", "error", errUser)
+                }
+        }
+
+        http.SetCookie(w, &http.Cookie{
+                Name:     "zitadel_access_token",
+                Value:    tok.AccessToken,
+                Path:     "/",
+                HttpOnly: true,
+                SameSite: http.SameSiteLaxMode,
+        })
+        http.Redirect(w, r, "/", http.StatusFound)
 }
 
 // handlePlainLogin verifies email/password and sets session cookie.
@@ -165,11 +198,8 @@ func (s *Server) handlePlainLogin(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid credentials", http.StatusUnauthorized)
 		return
 	}
-	token := uuid.Must(uuid.NewV7()).String()
-	h := s.handler
-	h.SessionsMu.Lock()
-	h.Sessions[token] = userID
-	h.SessionsMu.Unlock()
+        token := uuid.Must(uuid.NewV7()).String()
+        s.sessions.AddSession(token, userID)
 	http.SetCookie(w, &http.Cookie{
 		Name:     "sa_session",
 		Value:    token,
@@ -183,12 +213,9 @@ func (s *Server) handlePlainLogin(w http.ResponseWriter, r *http.Request) {
 // handleLogoutCallback clears session cookie.
 func (s *Server) handleLogoutCallback(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie("sa_session")
-	if err == nil {
-		h := s.handler
-		h.SessionsMu.Lock()
-		delete(h.Sessions, cookie.Value)
-		h.SessionsMu.Unlock()
-	}
+        if err == nil {
+                s.sessions.DeleteSession(cookie.Value)
+        }
 	http.SetCookie(w, &http.Cookie{
 		Name:   "sa_session",
 		Value:  "",

--- a/backend/internal/session/middleware.go
+++ b/backend/internal/session/middleware.go
@@ -1,39 +1,43 @@
 package session
 
 import (
-	"errors"
-	"log/slog"
-	"net/http"
-	"strings"
+    "errors"
+    "log/slog"
+    "net/http"
+    "strings"
+    "sync"
 
-	"github.com/ogen-go/ogen/middleware"
-	"github.com/samber/do/v2"
+    "github.com/ogen-go/ogen/middleware"
+    "github.com/samber/do/v2"
 
-	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/shadowapi/shadowapi/backend/internal/config"
-	"github.com/shadowapi/shadowapi/backend/internal/handler"
-	"github.com/shadowapi/shadowapi/backend/internal/zitadel"
-	"github.com/shadowapi/shadowapi/backend/pkg/query"
+    "github.com/jackc/pgx/v5/pgtype"
+    "github.com/jackc/pgx/v5/pgxpool"
+    "github.com/shadowapi/shadowapi/backend/internal/config"
+    "github.com/shadowapi/shadowapi/backend/internal/zitadel"
+    "github.com/shadowapi/shadowapi/backend/pkg/query"
 )
 
 // Middleware implements a pure Ogen middleware that checks for
 // either a valid Bearer token or a valid Zitadel session.
 type Middleware struct {
-	log          *slog.Logger
-	bearerSecret string
-	zitadel      *zitadel.Client
-	handler      *handler.Handler
+        log          *slog.Logger
+        bearerSecret string
+        zitadel      *zitadel.Client
+        db           *pgxpool.Pool
+        sessions     map[string]string
+        sessionsMu   sync.RWMutex
 }
 
 // Provide session middleware instance for the dependency injector
 func Provide(i do.Injector) (*Middleware, error) {
-	cfg := do.MustInvoke[*config.Config](i)
-	return &Middleware{
-		log:          do.MustInvoke[*slog.Logger](i),
-		bearerSecret: cfg.Auth.BearerToken,
-		zitadel:      zitadel.Provide(cfg),
-		handler:      do.MustInvoke[*handler.Handler](i),
-	}, nil
+        cfg := do.MustInvoke[*config.Config](i)
+        return &Middleware{
+                log:          do.MustInvoke[*slog.Logger](i),
+                bearerSecret: cfg.Auth.BearerToken,
+                zitadel:      zitadel.Provide(cfg),
+                db:           do.MustInvoke[*pgxpool.Pool](i),
+                sessions:     make(map[string]string),
+        }, nil
 }
 
 // OgenMiddleware satisfies Ogen's middleware.Middleware signature
@@ -54,28 +58,28 @@ func (m *Middleware) OgenMiddleware(req middleware.Request, next middleware.Next
 	}
 
 	// Check for Zitadel token either in header or cookie
-	if token := m.zitadelToken(r); token != "" {
-		info, err := m.zitadel.Introspect(req.Context, token)
-		if err == nil && info.Active {
-			q := query.New(m.handler.DB())
-			user, err := q.GetUserByZitadelSubject(req.Context, pgtype.Text{String: info.Subject, Valid: true})
-			if err == nil {
-				newCtx := WithIdentity(req.Context, Identity{ID: user.UUID.String()})
-				req.SetContext(newCtx)
-				return next(req)
-			}
-		}
-	}
+        if token := m.zitadelToken(r); token != "" {
+                info, err := m.zitadel.Introspect(req.Context, token)
+                if err == nil && info.Active {
+                        q := query.New(m.db)
+                        user, err := q.GetUserByZitadelSubject(req.Context, pgtype.Text{String: info.Subject, Valid: true})
+                        if err == nil {
+                                newCtx := WithIdentity(req.Context, Identity{ID: user.UUID.String()})
+                                req.SetContext(newCtx)
+                                return next(req)
+                        }
+                }
+        }
 
-	if cookie, err := r.Cookie("sa_session"); err == nil {
-		m.handler.SessionsMu.Lock()
-		uid, ok := m.handler.Sessions[cookie.Value]
-		m.handler.SessionsMu.Unlock()
-		if ok {
-			newCtx := WithIdentity(req.Context, Identity{ID: uid})
-			req.SetContext(newCtx)
-			return next(req)
-		}
+        if cookie, err := r.Cookie("sa_session"); err == nil {
+                m.sessionsMu.RLock()
+                uid, ok := m.sessions[cookie.Value]
+                m.sessionsMu.RUnlock()
+                if ok {
+                        newCtx := WithIdentity(req.Context, Identity{ID: uid})
+                        req.SetContext(newCtx)
+                        return next(req)
+                }
 	}
 
 	return middleware.Response{}, errors.New("unauthorized")
@@ -105,8 +109,22 @@ func (m *Middleware) zitadelToken(r *http.Request) string {
 			}
 		}
 	}
-	if cookie, err := r.Cookie("zitadel_access_token"); err == nil {
-		return cookie.Value
-	}
-	return ""
+        if cookie, err := r.Cookie("zitadel_access_token"); err == nil {
+                return cookie.Value
+        }
+        return ""
+}
+
+// AddSession registers a new session token for the given user ID.
+func (m *Middleware) AddSession(token, uid string) {
+        m.sessionsMu.Lock()
+        m.sessions[token] = uid
+        m.sessionsMu.Unlock()
+}
+
+// DeleteSession removes the given session token.
+func (m *Middleware) DeleteSession(token string) {
+        m.sessionsMu.Lock()
+        delete(m.sessions, token)
+        m.sessionsMu.Unlock()
 }


### PR DESCRIPTION
## Summary
- remove handler dependency from session middleware
- manage sessions within the middleware itself
- update server to use session middleware for login sessions
- automatically create users when authenticating via Zitadel

## Testing
- `go build ./cmd/shadowapi`
- `go vet ./...` *(fails: handler.E call has arguments but no formatting directives)*

------
https://chatgpt.com/codex/tasks/task_e_686ad778b2c4832a9a1121ce5f204760