### PR TITLE
Fix session status auth and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ init_admin:
   password: "change-me"
 ```
 
+For a remote deployment change `redirect_uri` to your public HTTPS domain, for example:
+
+```yaml
+auth:
+  zitadel:
+    redirect_uri: "https://example.com/auth/callback"
+```
+
 Use `https://` URLs for `redirect_uri` in production. `http://` is allowed only when ZITADEL development mode is enabled.
 
 The intercepted paths section is used by the reverse proxy middleware when a

--- a/backend/internal/session/errors.go
+++ b/backend/internal/session/errors.go
@@ -1,0 +1,20 @@
+package session
+
+// errWithCode wraps an error with an associated HTTP status code.
+type errWithCode struct {
+	err    error
+	status int
+}
+
+func (e *errWithCode) Error() string { return e.err.Error() }
+
+// StatusCode returns the associated HTTP status code.
+func (e *errWithCode) StatusCode() int { return e.status }
+
+// ErrWithCode creates a new error annotated with an HTTP status code.
+func ErrWithCode(code int, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &errWithCode{err: err, status: code}
+}


### PR DESCRIPTION
## Summary
- avoid 500 on `/api/v1/session` by allowing unauthenticated access
- return proper HTTP status for unauthorized requests
- expose session error wrapper
- update error handling to recognise errors with `StatusCode`
- document remote Zitadel redirect URI in README

## Testing
- `go test ./... -vet=off`

------
https://chatgpt.com/codex/tasks/task_e_686adf56c810832ab23fd1cd00e8a074