### PR TITLE
Update README with frontend env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,18 @@ Use `https://` URLs for `redirect_uri` in production. `http://` is allowed only 
 The intercepted paths section is used by the reverse proxy middleware when a
 frontend proxy is required.
 
+### Frontend Environment Variables
+
+The React frontend uses Vite environment variables to access ZITADEL. Before
+running `task dev-up` export these variables or define them in an `.env` file so
+that they match your backend configuration:
+
+```env
+VITE_ZITADEL_INSTANCE_URL=https://<your-zitadel-domain>
+VITE_ZITADEL_CLIENT_ID=<web-app-client-id>
+VITE_ZITADEL_REDIRECT_URI=http://localtest.me/auth/callback
+```
+
 ### Example ZITADEL Project Setup
 Zitadel instance runs on **reactima.com**. When creating a project and web app
 in Zitadel, add the following redirect URIs:


### PR DESCRIPTION
## Summary
- clarify that the frontend uses Vite env variables for ZITADEL
- show `.env` example for the frontend

## Testing
- `go test ./...` *(fails: E call has arguments but no formatting directives)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686af36220a4832abf117e2d1516bfb5