### PR TITLE
Update Traefik rules for auth paths

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -70,7 +70,7 @@ services:
       - ./spec:/spec/
     labels:
       - traefik.enable=true
-      - traefik.http.routers.shadowapi-api.rule=Host(`${DOMAIN}`)&&PathPrefix(`/api/`)||PathPrefix(`/assets/`)
+      - traefik.http.routers.shadowapi-api.rule=Host(`${DOMAIN}`) && (PathPrefix(`/api/`) || PathPrefix(`/assets/`) || PathPrefix(`/auth/`) || Path(`/login`) || PathPrefix(`/logout/`))
       - traefik.http.routers.shadowapi-api.entrypoints=${TRAEFIK_ENTRYPOINT}
       - traefik.http.services.shadowapi-api.loadbalancer.server.port=8080
 

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -55,7 +55,7 @@ services:
       - ./spec:/spec/
     labels:
       - traefik.enable=true
-      - traefik.http.routers.shadowapi-api.rule=Host(`${DOMAIN}`)&&PathPrefix(`/api/`)||PathPrefix(`/assets/`)
+      - traefik.http.routers.shadowapi-api.rule=Host(`${DOMAIN}`) && (PathPrefix(`/api/`) || PathPrefix(`/assets/`) || PathPrefix(`/auth/`) || Path(`/login`) || PathPrefix(`/logout/`))
       - traefik.http.routers.shadowapi-api.entrypoints=${TRAEFIK_ENTRYPOINT}
       - traefik.http.services.shadowapi-api.loadbalancer.server.port=8080
 


### PR DESCRIPTION
## Summary
- route OAuth callback and login/logout endpoints to backend

## Testing
- `go vet ./...` *(fails: E call has arguments but no formatting directives)*

------
https://chatgpt.com/codex/tasks/task_e_686b05ff1e2c832ab8dbbe58023246cf