### PR TITLE
Add admin password reset CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ task prod-down
 
 - Stops and removes the production environment containers.
 
+### Reset Admin Password
+
+Use the CLI to reset the password of a local (non‑ZITADEL) admin account. Run the command inside the backend service:
+
+```bash
+docker compose run --rm backend ./shadowapi reset-password <admin-email> <new-password>
+```
+
+Replace `<admin-email>` with the user's email and `<new-password>` with the new password.
+
 ---
 
 ## Common Tasks

--- a/backend/cmd/shadowapi/cmd/reset_password.go
+++ b/backend/cmd/shadowapi/cmd/reset_password.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/samber/do/v2"
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/bcrypt"
+)
+
+var resetPasswordCmd = &cobra.Command{
+	Use:   "reset-password [email] [new-password]",
+	Short: "Reset password for a local (non-ZITADEL) admin user",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		email := args[0]
+		pass := args[1]
+		ctx := do.MustInvoke[context.Context](injector)
+		dbp := do.MustInvoke[*pgxpool.Pool](injector)
+		log := do.MustInvoke[*slog.Logger](injector)
+
+		hash, err := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.DefaultCost)
+		if err != nil {
+			return err
+		}
+		res, err := dbp.Exec(ctx, `UPDATE "user" SET password=$1, updated_at=NOW() WHERE email=$2 AND (zitadel_subject IS NULL OR zitadel_subject='')`, string(hash), email)
+		if err != nil {
+			return err
+		}
+		if res.RowsAffected() == 0 {
+			return fmt.Errorf("user not found or managed by ZITADEL")
+		}
+		log.Info("password reset", "email", email)
+		return nil
+	},
+}
+
+func init() {
+	LoadDefault(resetPasswordCmd, nil)
+	rootCmd.AddCommand(resetPasswordCmd)
+}


### PR DESCRIPTION
## Summary
- add `reset-password` subcommand to reset local admin account credentials
- document how to run the new command with Docker Compose

## Testing
- `go vet ./...` *(fails: github.com/shadowapi/shadowapi/backend/internal/handler.E call has arguments but no formatting directives)*
- `go build ./cmd/shadowapi`


------
https://chatgpt.com/codex/tasks/task_e_686b1706c658832abba91e87392898b6