### PR TITLE
Fix login UUID usage and cache Go dependencies

### DIFF
--- a/backend/internal/handler/login.go
+++ b/backend/internal/handler/login.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/gofrs/uuid"
+	gouuid "github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"golang.org/x/crypto/bcrypt"
@@ -37,6 +38,9 @@ func (h *Handler) SessionStatus(ctx context.Context) (*api.SessionStatus, error)
 		return &api.SessionStatus{Active: false}, nil
 	}
 	out := api.SessionStatus{Active: true}
-	out.SetUuid(id.ID)
+	uid, err := gouuid.Parse(id.ID)
+	if err == nil {
+		out.SetUUID(api.NewOptUUID(uid))
+	}
 	return &out, nil
 }

--- a/devops/backend.dev.Dockerfile
+++ b/devops/backend.dev.Dockerfile
@@ -9,4 +9,8 @@ RUN \
   go install github.com/air-verse/air@v1.52.3 && \
   go install github.com/go-delve/delve/cmd/dlv@v1.22.1
 
+# Cache dependencies
+COPY backend/go.mod backend/go.sum ./
+RUN go mod download
+
 CMD ["air", "-c", ".air.toml"]


### PR DESCRIPTION
## Summary
- cache Go dependencies when building the development backend image
- fix SessionStatus handler to use the correct UUID type

## Testing
- `go test ./...` *(fails: github.com/shadowapi/shadowapi/backend/internal/handler build failed)*

------
https://chatgpt.com/codex/tasks/task_e_686c47efbfa8832a9ca6d36058b46494