### PR TITLE
Fix Zitadel PKCE flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,17 +136,12 @@ Use `https://` URLs for `redirect_uri` in production. `http://` is allowed only 
 The intercepted paths section is used by the reverse proxy middleware when a
 frontend proxy is required.
 
-### Frontend Environment Variables
+### Frontend Login Flow
 
-The React frontend uses Vite environment variables to access ZITADEL. Before
-running `task dev-up` export these variables or define them in an `.env` file so
-that they match your backend configuration:
-
-```env
-VITE_ZITADEL_INSTANCE_URL=https://<your-zitadel-domain>
-VITE_ZITADEL_CLIENT_ID=<web-app-client-id>
-VITE_ZITADEL_REDIRECT_URI=http://localtest.me/auth/callback
-```
+The frontend no longer constructs its own `/oauth/v2/authorize` URL. Instead it
+simply redirects the browser to `/login/zitadel`. The backend sets up the
+PKCE parameters, stores the short-lived verifier in a cookie and forwards the
+request to ZITADEL.
 
 ### Example ZITADEL Project Setup
 Zitadel instance runs on **reactima.com**. When creating a project and web app

--- a/front/src/shauth/LoginPage.tsx
+++ b/front/src/shauth/LoginPage.tsx
@@ -27,7 +27,9 @@ export function LoginPage() {
     );
   }
 
-  const loginUrl = `${import.meta.env.VITE_ZITADEL_INSTANCE_URL}/oauth/v2/authorize?client_id=${import.meta.env.VITE_ZITADEL_CLIENT_ID}&response_type=code&scope=openid&redirect_uri=${encodeURIComponent(import.meta.env.VITE_ZITADEL_REDIRECT_URI)}`;
+  const zitadelLogin = () => {
+    window.location.href = "/login/zitadel";
+  };
 
   return (
     <Flex
@@ -78,9 +80,7 @@ export function LoginPage() {
             alignSelf="end"
             marginTop="size-150"
             width="size-1250"
-            onPress={() => {
-              window.location.href = loginUrl;
-            }}
+            onPress={zitadelLogin}
           >
             Login with ZITADEL
           </Button>


### PR DESCRIPTION
## Summary
- implement PKCE verifier/challenge storage in backend `/login/zitadel`
- forward stored verifier during `/auth/callback` token exchange
- adjust Zitadel OAuth client to accept optional verifier
- update React login page to redirect to backend
- document new login flow in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx playwright test` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_686c708a8fa8832ab14a13992cb52dbd