### PR TITLE
Improve frontend auth flow

### DIFF
--- a/front/src/main.tsx
+++ b/front/src/main.tsx
@@ -6,9 +6,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App'
 
 const init = async () => {
+  const basename = import.meta.env.VITE_APP_BASENAME || '/ui'
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-      <BrowserRouter>
+      <BrowserRouter basename={basename}>
         <QueryClientProvider client={new QueryClient()}>
           <App />
         </QueryClientProvider>

--- a/front/src/shauth/LoginPage.tsx
+++ b/front/src/shauth/LoginPage.tsx
@@ -9,6 +9,8 @@ export function LoginPage() {
   const session = useQuery(sessionOptions())
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
 
   useEffect(() => {
     if (session.data?.active) {
@@ -43,21 +45,32 @@ export function LoginPage() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
           />
+          {errorMsg && (
+            <Text color="negative">{errorMsg}</Text>
+          )}
           <Button
             variant="primary"
             alignSelf="end"
             width="size-1250"
+            isDisabled={submitting}
             onPress={async () => {
+              setSubmitting(true)
+              setErrorMsg(null)
               const resp = await fetch('/login', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 credentials: 'include',
                 body: JSON.stringify({ email, password }),
               })
-              if (resp.ok) navigate('/')
+              setSubmitting(false)
+              if (resp.ok) {
+                navigate('/')
+              } else {
+                setErrorMsg('Invalid email or password')
+              }
             }}
           >
-            Login
+            {submitting ? 'Logging in...' : 'Login'}
           </Button>
           <Button variant="cta" alignSelf="end" marginTop="size-150" width="size-1250" onPress={zitadelLogin}>
             <span style={{ whiteSpace: 'nowrap' }}>Login with ZITADEL</span>

--- a/front/src/shauth/query.ts
+++ b/front/src/shauth/query.ts
@@ -7,6 +7,9 @@ export const sessionOptions = () => {
       const resp = await fetch("/api/v1/session", {
         credentials: "include",
       });
+      if (resp.status === 401) {
+        return { active: false };
+      }
       if (!resp.ok) {
         throw new Error("session check failed");
       }


### PR DESCRIPTION
## Summary
- handle 401 errors from `/api/v1/session` without throwing
- configure router basename for `/ui` deployments
- show login failures and loading state on login form

## Testing
- `npm run build`
- `npx playwright install` *(fails: missing dependencies)*
- `npx playwright test` *(fails: browser launch failed)*

------
https://chatgpt.com/codex/tasks/task_e_686d4626d64c832ab20c48f77ce4188d