### PR TITLE
Add config loading details

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,28 @@ Replace `<admin-email>` with the user's email and `<new-password>` with the new 
 - **Generate API Specs (Backend + Frontend):** `task api-gen`
 - **Run Playwright Tests (Frontend):** `task playwright-run`
 
+## Configuration
+
+Copy `backend/config.example.yaml` to `backend/config.yaml` and adjust the values
+to match your environment. Important settings include the Postgres connection,
+NATS.io broker and ZITADEL OAuth2 credentials:
+
+```yaml
+db:
+  uri: postgres://shadowapi:shadowapi@localhost:5432/shadowapi?sslmode=disable
+queue:
+  url: nats://localhost:4222
+  prefix: shadowapi
+auth:
+  zitadel:
+    instance_url: https://example.zitadel.cloud
+    service_client_id: client-id
+    service_client_secret: client-secret
+    api_key_file: ./api-key.json
+    audience: api-client-id
+    redirect_uri: http://localtest.me/auth/callback
+```
+
 ## ZITADEL Authentication
 
 To enable login via [ZITADEL](https://zitadel.com) create a service user and grant it the

--- a/backend/cmd/shadowapi/cmd/root.go
+++ b/backend/cmd/shadowapi/cmd/root.go
@@ -113,6 +113,9 @@ func LoadDefault(cmd *cobra.Command, modify func(cfg *config.Config)) {
 }
 
 func init() {
+	if envPath := os.Getenv("SA_CONFIG_PATH"); envPath != "" {
+		defaultConfigPath = envPath
+	}
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 

--- a/backend/config.example.yaml
+++ b/backend/config.example.yaml
@@ -4,7 +4,8 @@ log:
 server:
     host: ""
     port: 0
-db: {}
+db:
+    uri: "postgres://shadowapi:shadowapi@localhost:5432/shadowapi?sslmode=disable"
 api:
     specs_dir: ""
 jwt: {}
@@ -15,15 +16,18 @@ auth:
     ignore_https_error: false
     bearer_token: ""
     zitadel:
-        instance_url: ""
-        service_client_id: ""
-        service_client_secret: ""
-        api_key_file: ""
-        audience: ""
-        redirect_uri: ""
-        intercepted_paths: []
+        instance_url: "https://example.zitadel.cloud"
+        service_client_id: "client-id"
+        service_client_secret: "client-secret"
+        api_key_file: "./api-key.json"
+        audience: "api-client-id"
+        redirect_uri: "http://localtest.me/auth/callback"
+        intercepted_paths:
+            - "/.well-known/"
+            - "/oauth/"
+            - "/oidc/"
 worker:
     max_count: 0
 queue:
-    url: ""
-    prefix: ""
+    url: "nats://localhost:4222"
+    prefix: "shadowapi"


### PR DESCRIPTION
## Summary
- sample config values for Postgres, NATS and Zitadel
- document how to copy config file and show example settings
- allow overriding config path with `SA_CONFIG_PATH`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68835413c170832a95275aaab151a70a