### PR TITLE
Add SA_CONFIG_PATH debug logging

### DIFF
--- a/backend/cmd/shadowapi/cmd/root.go
+++ b/backend/cmd/shadowapi/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"log/slog"
 	"os"
 	"strings"
 
@@ -113,9 +114,12 @@ func LoadDefault(cmd *cobra.Command, modify func(cfg *config.Config)) {
 }
 
 func init() {
-	if envPath := os.Getenv("SA_CONFIG_PATH"); envPath != "" {
+	envPath := os.Getenv("SA_CONFIG_PATH")
+	slog.Info("env SA_CONFIG_PATH", "value", envPath)
+	if envPath != "" {
 		defaultConfigPath = envPath
 	}
+	slog.Info("config path in use", "path", defaultConfigPath)
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -118,7 +118,17 @@ type Config struct {
 // Provide config object instance for the dependency injector
 func Provide(i do.Injector) (*Config, error) {
 	cPath := do.MustInvokeNamed[string](i, "defaultConfigPath")
-	return Load(cPath)
+	slog.Info("loading configuration", "path", cPath)
+	cfg, err := Load(cPath)
+	if err != nil {
+		return nil, err
+	}
+	if data, err := yaml.Marshal(cfg); err == nil {
+		slog.Info("config loaded", "config", string(data))
+	} else {
+		slog.Error("marshal config", "err", err)
+	}
+	return cfg, nil
 }
 
 // Load creates a new Config instance
@@ -131,6 +141,7 @@ func Load(configPath string) (*Config, error) {
 		if err := env.Parse(config); err != nil {
 			slog.Error("failed to parse environment variables", "error", err)
 		}
+		slog.Info("SA_CONFIG_PATH after env parse", "value", os.Getenv("SA_CONFIG_PATH"))
 	}()
 
 	stat, err := os.Stat(configPath)

--- a/devops/backend.prod.Dockerfile
+++ b/devops/backend.prod.Dockerfile
@@ -20,6 +20,6 @@ COPY --from=builder /shadowapi ./shadowapi
 COPY front/dist ./dist
 
 EXPOSE 8080
-CMD ["/app/shadowapi", "serve"]
+CMD ["sh", "-c", "echo SA_CONFIG_PATH=$SA_CONFIG_PATH && /app/shadowapi serve"]
 
 


### PR DESCRIPTION
## Summary
- log SA_CONFIG_PATH usage during CLI initialization
- show config file path and final config structure when loading
- output SA_CONFIG_PATH value on container startup

## Testing
- `go test ./...` *(fails: call to slog.Logger.Info missing a final value)*

------
https://chatgpt.com/codex/tasks/task_e_6883da5da5f0832ab6dffd4fddece090